### PR TITLE
feat: add config, daily quests, focus combo, prestige, heatmap and sh…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,112 +1,222 @@
 
 <div align="center">
-<h1 style="text-align: center;">🎮 Gamify your Neovim experience 🎮</h1>
-
+<h1 style="text-align: center;">🎮 Gamify.nvim 🎮</h1>
 
 ![logo](https://github.com/user-attachments/assets/d24d6a76-76cb-4a75-a862-0aa1764e5e13)
 
-A small plugin to “gamify” your coding sessions in Neovim. It tracks your coding activity, rewards you with experience points (XP), and unlocks achievements based on various milestones—from writing lines of code to hitting daily streaks and fixing errors. It also gives you random compliments and xp just for using the best editor around. 
+**Turn your Neovim into an RPG experience.**  
+Track your activity, earn XP, level up, and unlock achievements while you code.
+
+[Features](#features) • [Installation](#installation--usage) • [Mini-Games](#mini-games) • [Challenges](#gamify-katas) • [Achievements](#achievements)
 </div>
 
-## Features
+---
 
-- **Daily Tracking**: Increments your day streak each time you open Neovim on a new day.  
-- **Line Counting**: Collects how many lines of code you’ve written per language.  
-- **Error Fixes**: Counts how many errors you fix (with optional checks that errors truly disappear).  
-- **XP and Levels**: Earn XP for tasks, achievements, or random “lucky” events.  
-- **Achievement Popups**: Unlock achievements that display a popup and confetti effect.
+## 🚀 Features
 
-## Screenshots  
-![telegram-cloud-photo-size-4-6037212632525687285-y](https://github.com/user-attachments/assets/398c0d50-cfb3-4a9b-8c0d-b0c6dba05dd9)
+- **Unified Dashboard**: Access everything from one place with `:Gamify`.
+- **Character Classes**: Are you a **Frontend Wizard**, **Systems Ninja**, or **Plugin Sorcerer**? Your role evolves based on your most-used languages!
+- **XP & Leveling System**: Earn XP for writing code, fixing bugs, and completing challenges. Watch your progress bar grow!
+- **Daily Quests**: 3 fresh objectives every day with progress tracking and a completion bonus.
+- **Focus Combo**: Code uninterrupted to build a focus streak that multiplies your XP (up to x3).
+- **Prestige System**: Hit the level cap, then prestige for a permanent XP bonus.
+- **Activity Heatmap**: A GitHub-style contribution graph of your coding, right inside Neovim (`:GamifyHeatmap`).
+- **Share Card**: Generate a shareable ASCII character card and yank it to your clipboard (`:GamifyShare`).
+- **Mini-Games**: Take a break with built-in games like **Vim Snake**, **Saper (Minesweeper)**, and **Sudoku**.
+- **Gamify Katas**: Solve 8 algorithmic challenges (Codewars-style) directly in your editor, with a bonus **kata of the day**.
+- **Clean Code Bonus**: Get rewarded for saving files with zero errors (once per buffer, no grinding).
+- **Achievement System**: 21 unique milestones with confetti effects and popups.
+- **Statusline Component**: Show your level, XP bar, and streak in lualine/heirline.
+- **Fully Configurable**: Tune every XP reward, quest, and feature via `setup()`.
+- **Fresh Repo Support**: Works seamlessly even in brand-new git repositories.
 
-![telegram-cloud-photo-size-4-6037212632525687286-y](https://github.com/user-attachments/assets/d9d20490-8781-46d9-bd90-436af5404ee1)
+---
 
-![telegram-cloud-photo-size-4-6037212632525687287-y](https://github.com/user-attachments/assets/6319b1fd-6481-4879-a653-f16fdc5e6660)
+## 📸 Screenshots
 
-## Video Preview
-
-![achievement-gif](https://github.com/user-attachments/assets/f5b07484-a700-47ee-97a7-5d13e9d4ebcf)
-
-## Commands
-- **`:Gamify`** – Show the status window (XP, level, achievements, lines, etc.)  
-- **`:Langstats`** – Show a bar chart of languages and line counts  
-- **`:Achievements`** – List your unlocked achievements.
-
-
-
-
-
-
+### The Dashboard
+Level, XP bar, role, prestige, focus combo, progress to your next achievement, daily quests, and the menu — all from `:Gamify`.
+<img width="1700" height="1013" alt="image" src="https://github.com/user-attachments/assets/2ee9536d-0c8e-4eb1-88f1-8248df3b1132" />
 
 
-## Installation & Usage
+### Activity Heatmap
+A GitHub-style contribution graph of your coding, via `:GamifyHeatmap`.
+![Uploading image.png…]()
 
-1. Install via your preferred plugin manager (e.g., `lazy.nvim`, `packer.nvim`, etc.).  
-2. Require as needed (e.g., `require('gamify')`). Configuration is not available yet.
-3. Start coding! Achievements will unlock automatically, and popups will appear.
 
+### Share Card
+A shareable ASCII character card you can yank to your clipboard, via `:GamifyShare`.
+<img width="436" height="322" alt="image" src="https://github.com/user-attachments/assets/1373860f-9e7f-4eda-b5f8-8537b8bdb1e1" />
+
+
+### Screenshots
+<img width="2028" height="1594" alt="image" src="https://github.com/user-attachments/assets/a1505784-f629-40cd-9bf4-1af510c990bb" />
+
+
+### Gamify Katas
+The kata picker (with the ⭐ kata of the day) and the in-editor Lua solution buffer.
+<img width="480" height="318" alt="image" src="https://github.com/user-attachments/assets/77e44a98-186c-460f-8a74-683acdd2c955" />
+<img width="716" height="422" alt="image" src="https://github.com/user-attachments/assets/5cb8ecec-2984-4cd9-9c75-339a900bca4a" />
+
+---
+
+## 📦 Installation & Usage
+
+### 1. Install via your preferred plugin manager
+
+**lazy.nvim**
 ```lua
--- lazy.nvim  
 {
   'grzegorzszczepanek/gamify.nvim',
   config = function()
-    require('gamify')
+    require('gamify').setup()
   end,
 }
 ```
 
-```lua
--- for lazy loading
-local add, later = MiniDeps.add, MiniDeps.later
+> **Note:** `gamify.nvim` no longer auto-initializes on `require`. You must call
+> `require('gamify').setup()` (optionally with a config table) for commands and
+> tracking to be registered.
 
-later(function()
-    add("GrzegorzSzczepanek/gamify.nvim")
-    require("gamify")
-end)
+### 2. Commands
+- **`:Gamify`** – Open the **Unified Dashboard** (Center of Command).
+- **`:GamifySnake`** – Launch the **Vim Snake** mini-game.
+- **`:GamifySaper`** – Launch the **Saper (Minesweeper)** mini-game.
+- **`:GamifySudoku`** – Launch the **Sudoku** mini-game.
+- **`:GamifyChallenges`** – Start solving **Gamify Katas**.
+- **`:GamifyHeatmap`** – View your activity heatmap.
+- **`:GamifyShare`** – Generate a shareable character card.
+- **`:GamifyStats`** – Quick stats line via `vim.notify`.
+- **`:GamifyPrestige`** – Prestige (resets XP for a permanent bonus).
+- **`:GamifyReset`** – Wipe all progress (asks for confirmation).
+- **`:LangStats`** – Detailed breakdown of lines per language.
+- **`:Achievements`** – View your trophy room.
 
-```
+---
 
+## 🐍 Mini-Games
 
-## Achievements
+### Vim Snake
+Feeling stuck? Type `:GamifySnake` and use `h`, `j`, `k`, `l` to control the snake. Each 🍎 you eat gives you **10 XP**!
+
+### Saper (Minesweeper)
+Classic Minesweeper directly in your editor. Type `:GamifySaper`.
+- **Controls**: `h, j, k, l` to move, `<Enter>` to reveal, `f` to flag.
+- **Reward**: Win the game to earn **200 XP**!
+
+### Sudoku
+Classic Sudoku with difficulty levels. Type `:GamifySudoku`.
+- **Controls**: `h, j, k, l` to move, `1-9` to enter numbers, `d` to change difficulty, `0/x` to clear.
+- **Reward**: Solve the puzzle to earn up to **500 XP**!
+
+---
+
+## 🏆 Gamify Katas
+Improve your Lua and algorithmic skills without leaving Neovim.
+1. Open the menu via `:Gamify` and press `c` (or run `:GamifyChallenges`).
+2. Select a challenge (e.g., *Reverse String*, *FizzBuzz*, *Fibonacci*).
+3. Write your solution and press `<Enter>` to run tests.
+4. Pass all tests to claim your reward!
+
+There are **8 katas**, each solvable once for XP. One is the **⭐ Kata of the Day**
+and awards **+50% XP** the first time you solve it each day. Solutions run in a
+sandbox, so `solution` won't leak into your global environment.
+
+---
+
+## 🎯 Daily Quests & Combos
+
+- **Daily Quests** — Every day you get 3 randomized objectives (write N lines,
+  make N commits, fix bugs, solve a kata, play a game…). Progress is tracked
+  live on the dashboard, and clearing all three grants a bonus.
+- **Focus Combo** — Keep coding without long breaks to build a focus streak.
+  Your XP multiplier rises the longer you stay in flow (up to x3), and resets
+  after you go idle.
+- **Prestige** — Once you reach the level cap (default 50), run `:GamifyPrestige`
+  to reset your XP in exchange for a permanent XP bonus that stacks each rank.
+
+---
+
+## 🏅 Achievements
 
 | **Achievement**            | **Description**                                                              | **XP**  |
 |----------------------------|------------------------------------------------------------------------------|--------:|
 | **Weekly Streak**          | Open Neovim every day for 7 consecutive days                                 | 500     |
-| **Two Weeks Streak**       | Open Neovim every day for 14 consecutive days                                | 1500    |
-| **One Month Streak**       | Open Neovim every day for 30 consecutive days                                | 4000    |
-| **Hundred lines**          | Write 100 lines of code                                                      | 100     |
-| **Thousand Lines**         | Write 1000 lines of code                                                     | 150     |
-| **Two Thousand Lines**     | Write 2000 lines of code                                                     | 350     |
-| **Five Thousand Lines**    | Write 5000 lines of code                                                     | 600     |
-| **Ten Thousand Lines**     | Write 10000 lines of code                                                    | 800     |
-| **Twenty Five Thousand Lines** | Write 25000 lines of code                                               | 2000    |
 | **Night Owl**              | Code for at least 3 hours between 11PM and 4AM five times                     | 1000    |
 | **Early Bird**             | Code for at least 3 hours between 6AM and 11AM five times                     | 1000    |
-| **Jack of Many**           | Write at least 1000 lines in at least 5 languages                            | 2500    |
 | **Polyglot**               | Write at least 1000 lines in at least 10 languages                           | 5000    |
-| **Marathoner**             | Code continuously for at least 6 hours                                       | 1800    |
-| **Git Apprentice**         | Make 10 total commits in your coding journey                                 | 300     |
-| **Git Journeyman**         | Make 50 total commits in your coding journey                                 | 1000    |
-| **Git Master**             | Make 100 total commits in your coding journey                                | 3000    |
 | **Commit Deity**           | Make 500 total commits in your coding journey                                | 8000    |
-| **Vim enjoyer**            | Spend at least 100 hours in nvim                                             | 4500    |
 | **Get a Life!**            | Spend at least 200 hours in nvim                                             | 9000    |
 
-## Contributing
-Contributions, whether they're bug fixes, new features, documentation improvements, or other enhancements, are always welcome. To ensure a smooth collaboration, please follow these steps:
+*(And many more... type `:Achievements` to see them all!)*
 
-1. **Open an Issue**: Before submitting a Pull Request (PR), please open an issue to discuss the proposed change. This helps us understand the problem or enhancement you are addressing and avoid duplicate work.
+---
 
-2. **Fork the Repository**: Create a copy of this repository in your own GitHub account by clicking the "Fork" button.
+## 📊 Statusline
 
-3. **Make Changes**: Implement your changes in a new branch. Use meaningful commit messages to describe your work.
+Show your level, an XP bar, and your streak in your statusline:
 
-4. **Submit a Pull Request**: Once your changes are ready, submit a PR to the main repository. Ensure that you:
-   - Reference the issue number (if applicable) in your PR description.
-   - Provide a clear and concise summary of your changes.
+```lua
+-- lualine example
+require('lualine').setup {
+  sections = {
+    lualine_x = {
+      function() return require('gamify.logic').get_statusline_bar() end,
+    },
+  },
+}
+```
 
-5. **Code Review**: Your PR will be reviewed, and feedback may be provided. 
+`get_statusline_bar(bar_width)` renders e.g. `Lvl 12 [████░░] 🔥7`.
+For a minimal variant use `get_statusline_text()` → `Lvl 12 🔥 7`.
 
+---
 
-## License
+## 🛠️ Configuration
+
+Pass a table to `setup()` to override any default. Shown below with defaults:
+
+```lua
+require('gamify').setup {
+  xp = {
+    per_lines = 10,        -- 1 XP per N lines written
+    per_keypresses = 50,   -- 1 XP per N keypresses
+    per_error_fixed = 5,   -- XP per resolved diagnostic error
+    clean_code = 15,       -- XP for saving a buffer with zero errors
+    new_day = 10,          -- XP for the first launch on a new day
+    random_luck = 50,      -- XP for the rare lucky bonus
+    snake_per_apple = 10,
+    saper_win = 200,
+  },
+  clean_code_once_per_buffer = true, -- prevent `:w` XP farming
+  random_luck_chance = 40,           -- 1-in-N chance per save / new day
+  focus = {
+    enabled = true,
+    idle_timeout_sec = 120,  -- a longer gap resets the combo
+    tier_seconds = 300,      -- every N focused seconds bumps the multiplier
+    max_multiplier = 3.0,
+  },
+  quests = {
+    enabled = true,
+    count = 3,               -- quests generated per day
+    completion_bonus = 200,  -- bonus XP for clearing all daily quests
+  },
+  leveling = { A = 0.001, B = 1.02 }, -- level = floor(1 + A * (xp ^ B))
+  prestige = {
+    enabled = true,
+    level_required = 50,
+    xp_bonus_per_rank = 0.05, -- +5% XP per prestige rank
+  },
+  ui = {
+    confetti = true,
+    popups = true,
+    xp_popups = true,
+    popup_timeout_ms = 5000,
+  },
+}
+```
+
+---
+
+## 📜 License
 Licensed under the [Apache License 2.0](LICENSE).

--- a/lua/gamify/achievements.lua
+++ b/lua/gamify/achievements.lua
@@ -30,7 +30,7 @@ local achievement_definitions = {
     description = 'Use the Gamify command for the first time',
     xp = 100,
     check = function()
-      return storage.load_data().gamify_cmd_count == 0
+      return (storage.load_data().gamify_cmd_count or 0) >= 1
     end,
   },
   {
@@ -113,7 +113,7 @@ local achievement_definitions = {
     xp = 1000,
     check = function()
       local data = storage.load_data()
-      return (data.code_nights or 0) == 4
+      return (data.code_nights or 0) >= 5
     end,
   },
 
@@ -123,7 +123,7 @@ local achievement_definitions = {
     xp = 1000,
     check = function()
       local data = storage.load_data()
-      return (data.code_mornings or 0) == 4
+      return (data.code_mornings or 0) >= 5
     end,
   },
 
@@ -211,30 +211,82 @@ function M.get_achievements_table_length()
   return utils.get_table_length(achievement_definitions)
 end
 
+M.definitions = achievement_definitions
+
+-- Closest locked milestone, for the dashboard's "progress to next" bar.
+function M.next_progress()
+  local data = storage.load_data()
+  local lines = data.lines_written or 0
+  local commits = #(data.commit_hashes or {})
+  local streak = data.day_streak or 1
+  local time = data.total_time or 0
+
+  local measurable = {
+    { 'Hundred lines', lines, 100 },
+    { 'Thousand Lines', lines, 1000 },
+    { 'Two Thousand Lines', lines, 2000 },
+    { 'Five Thousand Lines', lines, 5000 },
+    { 'Ten Thousand Lines', lines, 10000 },
+    { 'Twenty Five Thousand Lines', lines, 25000 },
+    { 'Git Apprentice', commits, 10 },
+    { 'Git Journeyman', commits, 50 },
+    { 'Git Master', commits, 100 },
+    { 'Commit Deity', commits, 500 },
+    { 'Weekly Streak', streak, 7 },
+    { 'Two Weeks Streak', streak, 14 },
+    { 'One Month Streak', streak, 30 },
+    { 'Vim enjoyer', time, 100 },
+    { 'Get a Life!', time, 200 },
+  }
+
+  local best
+  for _, m in ipairs(measurable) do
+    local name, current, target = m[1], m[2], m[3]
+    if not data.achievements[name] and current < target then
+      local percent = (current / target) * 100
+      if not best or percent > best.percent then
+        best = { name = name, current = current, target = target, percent = percent }
+      end
+    end
+  end
+  return best
+end
+
 function M.check_all_achievements()
   local data = storage.load_data()
-  local delay = 0
+  local newly_unlocked = {}
 
   for _, achievement in ipairs(achievement_definitions) do
     local already_unlocked = data.achievements[achievement.name] ~= nil
-    local meets_requirement = achievement.check()
-
-    if meets_requirement and not already_unlocked then
+    if not already_unlocked and achievement.check() then
       logic.add_xp(achievement.xp, achievement)
-
-      vim.defer_fn(function()
-        ui.show_special_popup(achievement.name)
-      end, delay)
-
-      delay = delay + 3000
+      table.insert(newly_unlocked, achievement)
     end
+  end
+
+  if #newly_unlocked == 0 then
+    return
+  end
+
+  if #newly_unlocked == 1 then
+    ui.show_special_popup(newly_unlocked[1].name)
+  else
+    local names = {}
+    for _, a in ipairs(newly_unlocked) do
+      table.insert(names, '• ' .. a.name)
+    end
+    ui.show_popup('Unlocked ' .. #newly_unlocked .. ' achievements!\n' .. table.concat(names, '\n'), 'Achievements', 'top_right')
+    ui.show_falling_confetti(30, 3000)
   end
 end
 
-function M.track_error_fixes()
-  local previous_error_count = 0
+local buffer_error_counts = {}
 
-  local diagnostics = vim.diagnostic.get(0)
+function M.track_error_fixes()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local previous_error_count = buffer_error_counts[bufnr] or 0
+
+  local diagnostics = vim.diagnostic.get(bufnr)
   local current_error_count = 0
 
   for _, diag in ipairs(diagnostics) do
@@ -248,9 +300,14 @@ function M.track_error_fixes()
     local data = storage.load_data()
     data.errors_fixed = (data.errors_fixed or 0) + resolved_errors
     storage.save_data(data)
+
+    local per = require('gamify.config').get().xp.per_error_fixed
+    logic.add_xp(resolved_errors * per)
+    require('gamify.quests').on_errors_fixed(resolved_errors)
+    ui.show_popup('Fixed ' .. resolved_errors .. ' error(s)! + ' .. (resolved_errors * per) .. ' XP', 'Bug Hunter', 'bottom_left')
   end
 
-  previous_error_count = current_error_count
+  buffer_error_counts[bufnr] = current_error_count
 end
 
 return M

--- a/lua/gamify/challenges.lua
+++ b/lua/gamify/challenges.lua
@@ -1,0 +1,155 @@
+local M = {}
+local logic = require 'gamify.logic'
+local katas = require 'gamify.katas'
+local storage = require 'gamify.storage'
+
+local challenges = katas.list
+
+local function is_completed(data, id)
+  return data.completed_katas and data.completed_katas[tostring(id)] == true
+end
+
+function M.show_challenges_menu()
+  local daily = katas.daily_id()
+  local data = storage.load_data()
+  local width = 56
+  local height = #challenges + 8
+  local buf = vim.api.nvim_create_buf(false, true)
+
+  local lines = { '  🏆 GAMIFY KATAS 🏆', '' }
+  for i, c in ipairs(challenges) do
+    local mark = is_completed(data, c.id) and '✔' or ' '
+    local star = (c.id == daily) and ' ⭐(daily +50%)' or ''
+    table.insert(lines, string.format('  [%s] %d. %s (%d XP)%s', mark, i, c.title, c.xp, star))
+  end
+  table.insert(lines, '')
+  table.insert(lines, '  Select a number to start')
+  table.insert(lines, '  (b) Back to Dashboard  (q) Quit')
+
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = 'editor',
+    width = width,
+    height = height,
+    row = math.floor((vim.o.lines - height) / 2),
+    col = math.floor((vim.o.columns - width) / 2),
+    style = 'minimal',
+    border = 'rounded',
+  })
+
+  for i = 1, #challenges do
+    vim.keymap.set('n', tostring(i), function()
+      vim.api.nvim_win_close(win, true)
+      M.start_challenge(challenges[i])
+    end, { buffer = buf })
+  end
+
+  vim.keymap.set('n', 'b', function()
+    vim.api.nvim_win_close(win, true)
+    require('gamify.ui').show_status_window(require('gamify.achievements').get_achievements_table_length())
+  end, { buffer = buf })
+
+  vim.keymap.set('n', 'q', function()
+    vim.api.nvim_win_close(win, true)
+  end, { buffer = buf })
+  vim.api.nvim_buf_set_option(buf, 'modifiable', false)
+end
+
+function M.start_challenge(challenge)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_option(buf, 'filetype', 'lua')
+
+  local header = {
+    '-- 🎯 Challenge: ' .. challenge.title,
+    '-- 📝 Description: ' .. challenge.description,
+    '-- 🚀 Press <Enter> to run tests | <Esc> to quit',
+    '',
+  }
+  vim.list_extend(header, vim.split(challenge.initial_code, '\n'))
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, header)
+
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = 'editor',
+    width = 80,
+    height = 20,
+    row = math.floor((vim.o.lines - 20) / 2),
+    col = math.floor((vim.o.columns - 80) / 2),
+    border = 'rounded',
+  })
+
+  vim.keymap.set('n', '<CR>', function()
+    M.run_tests(buf, challenge)
+  end, { buffer = buf })
+
+  vim.keymap.set('n', '<Esc>', function()
+    vim.api.nvim_win_close(win, true)
+  end, { buffer = buf })
+end
+
+function M.run_tests(buf, challenge)
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  local code = table.concat(lines, '\n')
+
+  local func, err = loadstring(code)
+  if not func then
+    vim.api.nvim_err_writeln('❌ Syntax Error: ' .. err)
+    return
+  end
+
+  -- Run the user's code in a sandbox so `solution` doesn't leak into globals.
+  local env = setmetatable({}, { __index = _G })
+  setfenv(func, env)
+  local status, exec_err = pcall(func)
+  if not status then
+    vim.api.nvim_err_writeln('❌ Execution Error: ' .. tostring(exec_err))
+    return
+  end
+
+  local solution = env.solution
+  if type(solution) ~= 'function' then
+    vim.api.nvim_err_writeln("❌ Error: Function 'solution' is not defined!")
+    return
+  end
+
+  local passed = 0
+  for _, test in ipairs(challenge.tests) do
+    local success, result = pcall(solution, test.input)
+    if success and vim.deep_equal(result, test.expected) then
+      passed = passed + 1
+    end
+  end
+
+  if passed == #challenge.tests then
+    local data = storage.load_data()
+    local ui = require 'gamify.ui'
+
+    if is_completed(data, challenge.id) then
+      ui.show_popup('All tests passed! (already solved — no XP this time)', 'CHALLENGE COMPLETE', 'top_right')
+      pcall(vim.api.nvim_win_close, 0, true)
+      return
+    end
+
+    -- daily kata bonus: +50% XP, once per day
+    local award = challenge.xp
+    local today = os.date '%Y-%m-%d'
+    if challenge.id == katas.daily_id() and data.daily_kata_done ~= today then
+      award = math.floor(challenge.xp * 1.5)
+      data.daily_kata_done = today
+    end
+
+    data.completed_katas = data.completed_katas or {}
+    data.completed_katas[tostring(challenge.id)] = true
+    storage.save_data(data)
+
+    logic.add_xp(award)
+    require('gamify.quests').on_kata()
+    ui.show_popup('All tests passed! 🏆\nYou gained ' .. award .. ' XP', 'CHALLENGE COMPLETE', 'top_right')
+    ui.show_falling_confetti(30, 2000)
+    pcall(vim.api.nvim_win_close, 0, true)
+  else
+    vim.api.nvim_err_writeln(string.format('❌ Failed: %d/%d tests passed. Keep trying!', passed, #challenge.tests))
+  end
+end
+
+return M

--- a/lua/gamify/config.lua
+++ b/lua/gamify/config.lua
@@ -1,0 +1,64 @@
+local M = {}
+
+M.defaults = {
+  xp = {
+    per_lines = 10,
+    per_keypresses = 50,
+    per_error_fixed = 5,
+    clean_code = 15,
+    new_day = 10,
+    random_luck = 50,
+    snake_per_apple = 10,
+    saper_win = 200,
+  },
+
+  clean_code_once_per_buffer = true,
+  random_luck_chance = 40,
+
+  focus = {
+    enabled = true,
+    idle_timeout_sec = 120,
+    tier_seconds = 300,
+    max_multiplier = 3.0,
+  },
+
+  quests = {
+    enabled = true,
+    count = 3,
+    completion_bonus = 200,
+  },
+
+  -- level = floor(1 + A * (xp ^ B))
+  leveling = {
+    A = 0.001,
+    B = 1.02,
+  },
+
+  prestige = {
+    enabled = true,
+    level_required = 50,
+    xp_bonus_per_rank = 0.05,
+  },
+
+  ui = {
+    confetti = true,
+    popups = true,
+    xp_popups = true,
+    popup_timeout_ms = 5000,
+  },
+
+  use_vim_notify = false,
+}
+
+M.options = vim.deepcopy(M.defaults)
+
+function M.setup(opts)
+  M.options = vim.tbl_deep_extend('force', vim.deepcopy(M.defaults), opts or {})
+  return M.options
+end
+
+function M.get()
+  return M.options
+end
+
+return M

--- a/lua/gamify/focus.lua
+++ b/lua/gamify/focus.lua
@@ -1,0 +1,65 @@
+local M = {}
+
+local config = require 'gamify.config'
+
+local state = {
+  session_start = nil,
+  last_activity = nil,
+}
+
+local function now_ms()
+  return vim.loop.now()
+end
+
+function M.tick()
+  local cfg = config.get().focus
+  if not cfg.enabled then
+    return
+  end
+
+  local t = now_ms()
+  if not state.last_activity or (t - state.last_activity) > cfg.idle_timeout_sec * 1000 then
+    state.session_start = t
+  end
+  state.last_activity = t
+end
+
+function M.focused_seconds()
+  local cfg = config.get().focus
+  if not cfg.enabled or not state.session_start or not state.last_activity then
+    return 0
+  end
+  if (now_ms() - state.last_activity) > cfg.idle_timeout_sec * 1000 then
+    return 0
+  end
+  return (state.last_activity - state.session_start) / 1000
+end
+
+function M.current_multiplier()
+  local cfg = config.get().focus
+  if not cfg.enabled then
+    return 1
+  end
+  local secs = M.focused_seconds()
+  if secs <= 0 then
+    return 1
+  end
+  local tiers = math.floor(secs / cfg.tier_seconds)
+  return math.min(1 + tiers * 0.5, cfg.max_multiplier)
+end
+
+function M.status_text()
+  local secs = M.focused_seconds()
+  if secs <= 0 then
+    return 'Focus: idle (x1.0)'
+  end
+  local mins = math.floor(secs / 60)
+  return string.format('Focus: %dm streak (x%.1f)', mins, M.current_multiplier())
+end
+
+function M.flush()
+  state.session_start = nil
+  state.last_activity = nil
+end
+
+return M

--- a/lua/gamify/games.lua
+++ b/lua/gamify/games.lua
@@ -1,0 +1,504 @@
+local M = {}
+local logic = require 'gamify.logic'
+local ui = require 'gamify.ui'
+
+function M.start_snake()
+  require('gamify.quests').on_game()
+  local width = 60
+  local height = 25
+  local buf = vim.api.nvim_create_buf(false, true)
+  local win_opts = {
+    relative = 'editor',
+    width = width,
+    height = height,
+    row = math.floor((vim.o.lines - height) / 2),
+    col = math.floor((vim.o.columns - width) / 2),
+    style = 'minimal',
+    border = 'rounded',
+    title = ' 🐍 Vim Snake (h,j,k,l) ',
+    title_pos = 'center',
+  }
+  local win = vim.api.nvim_open_win(buf, true, win_opts)
+
+  -- Game state
+  local snake = { { x = 10, y = 10 }, { x = 10, y = 11 }, { x = 10, y = 12 } }
+  local direction = { x = 0, y = -1 } -- Start moving up
+  local food = { x = math.random(width), y = math.random(height) }
+  local score = 0
+  local game_over = false
+
+  local function draw()
+    if not vim.api.nvim_buf_is_valid(buf) then
+      return
+    end
+    local lines = {}
+    for y = 1, height do
+      local line = ''
+      for x = 1, width do
+        local is_snake = false
+        for i, part in ipairs(snake) do
+          if part.x == x and part.y == y then
+            line = line .. (i == 1 and 'O' or 'o')
+            is_snake = true
+            break
+          end
+        end
+        if not is_snake then
+          if food.x == x and food.y == y then
+            line = line .. '🍎'
+          else
+            line = line .. ' '
+          end
+        end
+      end
+      table.insert(lines, line)
+    end
+    vim.api.nvim_buf_set_option(buf, 'modifiable', true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    vim.api.nvim_buf_set_option(buf, 'modifiable', false)
+  end
+
+  local timer = vim.loop.new_timer()
+  local function update()
+    if game_over then
+      timer:stop()
+      timer:close()
+      return
+    end
+
+    local head = { x = snake[1].x + direction.x, y = snake[1].y + direction.y }
+
+    -- Collisions
+    if head.x < 1 or head.x > width or head.y < 1 or head.y > height then
+      game_over = true
+    end
+    for _, part in ipairs(snake) do
+      if head.x == part.x and head.y == part.y then
+        game_over = true
+      end
+    end
+
+    if not game_over then
+      table.insert(snake, 1, head)
+      if head.x == food.x and head.y == food.y then
+        score = score + 1
+        food = { x = math.random(width), y = math.random(height) }
+      else
+        table.remove(snake)
+      end
+      draw()
+    else
+      local xp_reward = score * 10
+      logic.add_xp(xp_reward)
+      
+      -- Update high score
+      local storage = require('gamify.storage')
+      local data = storage.load_data()
+      if score > (data.high_scores.snake or 0) then
+        data.high_scores.snake = score
+        storage.save_data(data)
+        vim.schedule(function()
+          require('gamify.ui').show_popup("New High Score: " .. score .. "! 🏆", "Snake Record", "top_right")
+        end)
+      end
+
+      vim.schedule(function()
+        vim.api.nvim_err_writeln('Game Over! Score: ' .. score .. ' | XP Gained: ' .. xp_reward)
+        -- Give a moment to see the score before returning
+        vim.defer_fn(function()
+          if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_close(win, true)
+          end
+          require('gamify.ui').show_status_window(require('gamify.achievements').get_achievements_table_length())
+        end, 2000)
+      end)
+    end
+  end
+
+  -- Keybindings
+  local function set_dir(x, y)
+    -- Prevent 180 degree turns
+    if (x ~= 0 and direction.x == 0) or (y ~= 0 and direction.y == 0) then
+      direction = { x = x, y = y }
+    end
+  end
+
+  vim.keymap.set('n', 'h', function() set_dir(-1, 0) end, { buffer = buf })
+  vim.keymap.set('n', 'l', function() set_dir(1, 0) end, { buffer = buf })
+  vim.keymap.set('n', 'k', function() set_dir(0, -1) end, { buffer = buf })
+  vim.keymap.set('n', 'j', function() set_dir(0, 1) end, { buffer = buf })
+  vim.keymap.set('n', '<Esc>', function()
+    game_over = true
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
+    require('gamify.ui').show_status_window(require('gamify.achievements').get_achievements_table_length())
+  end, { buffer = buf })
+  vim.keymap.set('n', 'q', function()
+    game_over = true
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
+    require('gamify.ui').show_status_window(require('gamify.achievements').get_achievements_table_length())
+  end, { buffer = buf })
+
+  timer:start(0, 150, vim.schedule_wrap(update))
+end
+
+function M.start_minesweeper()
+  require('gamify.quests').on_game()
+  local width = 10
+  local height = 10
+  local mine_count = 15
+  local buf = vim.api.nvim_create_buf(false, true)
+  local win_opts = {
+    relative = 'editor',
+    width = width * 5 + 4,
+    height = height * 2 + 2,
+    row = math.floor((vim.o.lines - (height * 2 + 2)) / 2),
+    col = math.floor((vim.o.columns - (width * 5 + 4)) / 2),
+    style = 'minimal',
+    border = 'rounded',
+    title = ' 💣 Saper (h,j,k,l, <CR>:Reveal, f:Flag) ',
+    title_pos = 'center',
+  }
+  local win = vim.api.nvim_open_win(buf, true, win_opts)
+
+  -- Game state
+  local board = {}
+  local revealed = {}
+  local flags = {}
+  local cursor = { x = 1, y = 1 }
+  local game_over = false
+  local first_click = true
+  local start_time = nil
+
+  local function init_board(safe_x, safe_y)
+    start_time = os.time()
+    board = {}
+    for y = 1, height do
+      board[y] = {}
+      for x = 1, width do board[y][x] = 0 end
+    end
+
+    local placed = 0
+    while placed < mine_count do
+      local rx, ry = math.random(width), math.random(height)
+      if board[ry][rx] ~= -1 and (rx ~= safe_x or ry ~= safe_y) then
+        board[ry][rx] = -1
+        placed = placed + 1
+      end
+    end
+
+    for y = 1, height do
+      for x = 1, width do
+        if board[y][x] ~= -1 then
+          local count = 0
+          for dy = -1, 1 do
+            for dx = -1, 1 do
+              local ny, nx = y + dy, x + dx
+              if board[ny] and board[ny][nx] == -1 then count = count + 1 end
+            end
+          end
+          board[y][x] = count
+        end
+      end
+    end
+  end
+
+  local function draw()
+    local lines = { "" }
+    for y = 1, height do
+      local line = '  '
+      for x = 1, width do
+        local char = '■ '
+        if revealed[y] and revealed[y][x] then
+          if board[y][x] == -1 then char = '💣'
+          elseif board[y][x] == 0 then char = '· '
+          else char = board[y][x] .. ' ' end
+        elseif flags[y] and flags[y][x] then
+          char = '🚩'
+        end
+        
+        if cursor.x == x and cursor.y == y then
+          char = '[' .. char:sub(1, 2):gsub("%s+", "") .. ']'
+          if #char == 3 then char = char .. " " end
+        else
+          char = ' ' .. char .. ' '
+        end
+        line = line .. char
+      end
+      table.insert(lines, line)
+      table.insert(lines, "")
+    end
+    vim.api.nvim_buf_set_option(buf, 'modifiable', true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    vim.api.nvim_buf_set_option(buf, 'modifiable', false)
+  end
+
+  local function reveal(x, y)
+    if x < 1 or x > width or y < 1 or y > height or (revealed[y] and revealed[y][x]) or (flags[y] and flags[y][x]) then return end
+    revealed[y] = revealed[y] or {}
+    revealed[y][x] = true
+
+    if board[y][x] == -1 then
+      game_over = true
+      return
+    end
+
+    if board[y][x] == 0 then
+      for dy = -1, 1 do
+        for dx = -1, 1 do reveal(x + dx, y + dy) end
+      end
+    end
+  end
+
+  local function check_win()
+    local revealed_count = 0
+    for y = 1, height do
+      for x = 1, width do
+        if revealed[y] and revealed[y][x] then revealed_count = revealed_count + 1 end
+      end
+    end
+    if revealed_count == (width * height - mine_count) then
+      local time_taken = os.difftime(os.time(), start_time)
+      logic.add_xp(200)
+
+      -- Update best time
+      local storage = require('gamify.storage')
+      local data = storage.load_data()
+      if not data.high_scores.saper or time_taken < data.high_scores.saper then
+        data.high_scores.saper = time_taken
+        storage.save_data(data)
+        vim.schedule(function()
+          require('gamify.ui').show_popup("New Best Time: " .. time_taken .. "s! 🏆", "Saper Record", "top_right")
+        end)
+      end
+
+      require('gamify.ui').show_popup("You Won Saper! +200 XP 🏆", "Victory", "top_right")
+      require('gamify.ui').show_falling_confetti(30, 2000)
+      vim.api.nvim_win_close(win, true)
+      require('gamify.ui').show_status_window(require('gamify.achievements').get_achievements_table_length())
+    end
+  end
+
+  local function handle_reveal()
+    if game_over then return end
+    if first_click then
+      init_board(cursor.x, cursor.y)
+      first_click = false
+    end
+    reveal(cursor.x, cursor.y)
+    if game_over then
+      vim.api.nvim_err_writeln("BOOM! Game Over.")
+      vim.defer_fn(function()
+        if vim.api.nvim_win_is_valid(win) then vim.api.nvim_win_close(win, true) end
+        require('gamify.ui').show_status_window(require('gamify.achievements').get_achievements_table_length())
+      end, 2000)
+    else
+      check_win()
+    end
+    draw()
+  end
+
+  local function toggle_flag()
+    if revealed[cursor.y] and revealed[cursor.y][cursor.x] then return end
+    flags[cursor.y] = flags[cursor.y] or {}
+    flags[cursor.y][cursor.x] = not flags[cursor.y][cursor.x]
+    draw()
+  end
+
+  vim.keymap.set('n', 'h', function() cursor.x = math.max(1, cursor.x - 1); draw() end, { buffer = buf })
+  vim.keymap.set('n', 'l', function() cursor.x = math.min(width, cursor.x + 1); draw() end, { buffer = buf })
+  vim.keymap.set('n', 'k', function() cursor.y = math.max(1, cursor.y - 1); draw() end, { buffer = buf })
+  vim.keymap.set('n', 'j', function() cursor.y = math.min(height, cursor.y + 1); draw() end, { buffer = buf })
+  vim.keymap.set('n', '<CR>', handle_reveal, { buffer = buf })
+  vim.keymap.set('n', 'f', toggle_flag, { buffer = buf })
+  vim.keymap.set('n', '<Esc>', function()
+    vim.api.nvim_win_close(win, true)
+    require('gamify.ui').show_status_window(require('gamify.achievements').get_achievements_table_length())
+  end, { buffer = buf })
+  vim.keymap.set('n', 'q', function()
+    vim.api.nvim_win_close(win, true)
+    require('gamify.ui').show_status_window(require('gamify.achievements').get_achievements_table_length())
+  end, { buffer = buf })
+
+  draw()
+end
+
+function M.start_sudoku()
+  require('gamify.quests').on_game()
+  local buf = vim.api.nvim_create_buf(false, true)
+  local width = 55
+  local height = 25
+  local win_opts = {
+    relative = 'editor',
+    width = width,
+    height = height,
+    row = math.floor((vim.o.lines - height) / 2),
+    col = math.floor((vim.o.columns - width) / 2),
+    style = 'minimal',
+    border = 'rounded',
+    title = ' 🧩 Sudoku (h,j,k,l, 1-9:Enter, 0/x:Clear) ',
+    title_pos = 'center',
+  }
+  local win = vim.api.nvim_open_win(buf, true, win_opts)
+
+  local grid = {}
+  local initial = {}
+  local cursor = { x = 0, y = 0 }
+  local difficulty = "Medium"
+  local start_time = os.time()
+
+  local function is_valid(g, r, c, val)
+    for i = 0, 8 do
+      if g[r][i] == val or g[i][c] == val then return false end
+    end
+    local br, bc = math.floor(r / 3) * 3, math.floor(c / 3) * 3
+    for i = 0, 2 do
+      for j = 0, 2 do
+        if g[br + i][bc + j] == val then return false end
+      end
+    end
+    return true
+  end
+
+  local function solve(g)
+    for r = 0, 8 do
+      for c = 0, 8 do
+        if g[r][c] == 0 then
+          local nums = {1,2,3,4,5,6,7,8,9}
+          for i = #nums, 2, -1 do
+            local j = math.random(i)
+            nums[i], nums[j] = nums[j], nums[i]
+          end
+          for _, val in ipairs(nums) do
+            if is_valid(g, r, c, val) then
+              g[r][c] = val
+              if solve(g) then return true end
+              g[r][c] = 0
+            end
+          end
+          return false
+        end
+      end
+    end
+    return true
+  end
+
+  local function generate()
+    grid = {}
+    for i = 0, 8 do grid[i] = {}; for j = 0, 8 do grid[i][j] = 0 end end
+    solve(grid)
+    local clues = difficulty == "Easy" and 45 or (difficulty == "Hard" and 25 or 35)
+    local removed = 0
+    while removed < (81 - clues) do
+      local r, c = math.random(0, 8), math.random(0, 8)
+      if grid[r][c] ~= 0 then
+        grid[r][c] = 0
+        removed = removed + 1
+      end
+    end
+    initial = {}
+    for r = 0, 8 do
+      initial[r] = {}
+      for c = 0, 8 do initial[r][c] = grid[r][c] ~= 0 end
+    end
+  end
+
+  local function draw()
+    local lines = { "", ui.center_text("Difficulty: " .. difficulty .. " (Press d to change)", width), "" }
+    for r = 0, 8 do
+      local line = "      "
+      if r > 0 and r % 3 == 0 then 
+        table.insert(lines, "      " .. string.rep("—", 37))
+        table.insert(lines, "")
+      end
+      for c = 0, 8 do
+        if c > 0 and c % 3 == 0 then line = line .. "| " end
+        local val = grid[r][c] == 0 and "." or tostring(grid[r][c])
+        if cursor.x == c and cursor.y == r then
+          line = line .. "[" .. val .. "] "
+        else
+          line = line .. " " .. val .. "  "
+        end
+      end
+      table.insert(lines, line)
+      table.insert(lines, "")
+    end
+    vim.api.nvim_buf_set_option(buf, 'modifiable', true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    vim.api.nvim_buf_set_option(buf, 'modifiable', false)
+  end
+
+  local function check_win()
+    for r = 0, 8 do
+      for c = 0, 8 do
+        if grid[r][c] == 0 then return end
+        local v = grid[r][c]
+        grid[r][c] = 0
+        if not is_valid(grid, r, c, v) then
+          grid[r][c] = v
+          return
+        end
+        grid[r][c] = v
+      end
+    end
+    local time_taken = os.difftime(os.time(), start_time)
+    local xp = difficulty == "Easy" and 100 or (difficulty == "Hard" and 500 or 250)
+    logic.add_xp(xp)
+
+    -- Update best time
+    local storage = require('gamify.storage')
+    local data = storage.load_data()
+    if not data.high_scores.sudoku or time_taken < data.high_scores.sudoku then
+      data.high_scores.sudoku = time_taken
+      storage.save_data(data)
+      vim.schedule(function()
+        require('gamify.ui').show_popup("New Best Time: " .. time_taken .. "s! 🏆", "Sudoku Record", "top_right")
+      end)
+    end
+
+    require('gamify.ui').show_popup("Sudoku Solved! +" .. xp .. " XP 🏆", "Victory", "top_right")
+    require('gamify.ui').show_falling_confetti(30, 2000)
+    vim.api.nvim_win_close(win, true)
+    require('gamify.ui').show_status_window(require('gamify.achievements').get_achievements_table_length())
+  end
+
+  generate()
+
+  vim.keymap.set('n', 'h', function() cursor.x = (cursor.x - 1 + 9) % 9; draw() end, { buffer = buf })
+  vim.keymap.set('n', 'l', function() cursor.x = (cursor.x + 1) % 9; draw() end, { buffer = buf })
+  vim.keymap.set('n', 'k', function() cursor.y = (cursor.y - 1 + 9) % 9; draw() end, { buffer = buf })
+  vim.keymap.set('n', 'j', function() cursor.y = (cursor.y + 1) % 9; draw() end, { buffer = buf })
+  vim.keymap.set('n', 'd', function()
+    if difficulty == "Easy" then difficulty = "Medium"
+    elseif difficulty == "Medium" then difficulty = "Hard"
+    else difficulty = "Easy" end
+    generate(); draw()
+  end, { buffer = buf })
+
+  for i = 1, 9 do
+    vim.keymap.set('n', tostring(i), function()
+      if not initial[cursor.y][cursor.x] then
+        grid[cursor.y][cursor.x] = i
+        draw(); check_win()
+      end
+    end, { buffer = buf })
+  end
+  vim.keymap.set('n', '0', function() if not initial[cursor.y][cursor.x] then grid[cursor.y][cursor.x] = 0; draw() end end, { buffer = buf })
+  vim.keymap.set('n', 'x', function() if not initial[cursor.y][cursor.x] then grid[cursor.y][cursor.x] = 0; draw() end end, { buffer = buf })
+
+  vim.keymap.set('n', '<Esc>', function()
+    vim.api.nvim_win_close(win, true)
+    require('gamify.ui').show_status_window(require('gamify.achievements').get_achievements_table_length())
+  end, { buffer = buf })
+  vim.keymap.set('n', 'q', function()
+    vim.api.nvim_win_close(win, true)
+    require('gamify.ui').show_status_window(require('gamify.achievements').get_achievements_table_length())
+  end, { buffer = buf })
+
+  draw()
+end
+
+return M

--- a/lua/gamify/init.lua
+++ b/lua/gamify/init.lua
@@ -1,11 +1,14 @@
 local M = {}
 
 local data_file = vim.fn.stdpath 'data' .. '/gamify/data.json'
+local config = require 'gamify.config'
 local ui = require 'gamify.ui'
 local logic = require 'gamify.logic'
 local storage = require 'gamify.storage'
 local achievements = require 'gamify.achievements'
 local utils = require 'gamify.utils'
+local quests = require 'gamify.quests'
+local focus = require 'gamify.focus'
 
 local function ensure_data_file()
   local data_dir = vim.fn.stdpath 'data' .. '/gamify'
@@ -23,24 +26,11 @@ local function ensure_data_file()
   end
 end
 
-function M.setup()
-  -- M.setup gets called when the plugin gets required by eg. user's package manager
-  ensure_data_file()
-
-  local data = storage.load_data()
-  data.last_entry = os.date('%Y-%m-%d %H:%M:%S')
-  storage.save_data(data)
-
-  if storage.log_new_day() then
-    logic.add_xp(10)
-    ui.random_luck_popup()
-    utils.calculate_all_lines_written()
-    utils.check_streak()
-    achievements.check_all_achievements()
-  end
-
+local function register_commands()
   vim.api.nvim_create_user_command('Gamify', function()
-    data.gamify_cmd_count = data.gamify_cmd_count + 1
+    local data = storage.load_data()
+    data.gamify_cmd_count = (data.gamify_cmd_count or 0) + 1
+    storage.save_data(data)
     achievements.check_all_achievements()
     ui.show_status_window(achievements.get_achievements_table_length())
   end, {})
@@ -53,30 +43,122 @@ function M.setup()
     ui.show_achievements()
   end, {})
 
+  vim.api.nvim_create_user_command('GamifySnake', function()
+    require('gamify.games').start_snake()
+  end, {})
+
+  vim.api.nvim_create_user_command('GamifyChallenges', function()
+    require('gamify.challenges').show_challenges_menu()
+  end, {})
+
+  vim.api.nvim_create_user_command('GamifySaper', function()
+    require('gamify.games').start_minesweeper()
+  end, {})
+
+  vim.api.nvim_create_user_command('GamifySudoku', function()
+    require('gamify.games').start_sudoku()
+  end, {})
+
+  vim.api.nvim_create_user_command('GamifyHeatmap', function()
+    ui.show_heatmap()
+  end, {})
+
+  vim.api.nvim_create_user_command('GamifyShare', function()
+    ui.show_share_card()
+  end, {})
+
+  vim.api.nvim_create_user_command('GamifyStats', function()
+    local data = storage.load_data()
+    local lvl = data.level or 1
+    vim.notify(
+      string.format(
+        'Gamify: Lvl %d | XP %d | %d lines | %d commits | streak %d | prestige %d',
+        lvl,
+        math.floor(data.xp or 0),
+        data.lines_written or 0,
+        #(data.commit_hashes or {}),
+        data.day_streak or 1,
+        data.prestige or 0
+      ),
+      vim.log.levels.INFO,
+      { title = 'Gamify' }
+    )
+  end, {})
+
+  vim.api.nvim_create_user_command('GamifyPrestige', function()
+    logic.prestige()
+  end, {})
+
+  vim.api.nvim_create_user_command('GamifyReset', function()
+    vim.ui.input({ prompt = 'Type RESET to wipe all Gamify progress: ' }, function(input)
+      if input == 'RESET' then
+        storage.save_data(vim.deepcopy(storage.data_json_format))
+        vim.notify('Gamify progress has been reset.', vim.log.levels.WARN, { title = 'Gamify' })
+      else
+        vim.notify('Reset cancelled.', vim.log.levels.INFO, { title = 'Gamify' })
+      end
+    end)
+  end, {})
+end
+
+local function register_autocommands()
+  local group = vim.api.nvim_create_augroup('Gamify', { clear = true })
+
   vim.api.nvim_create_autocmd('BufWritePost', {
+    group = group,
     pattern = '*',
     callback = function()
       ui.random_luck_popup()
       logic.track_lines()
       achievements.track_error_fixes()
       utils.calculate_all_lines_written()
+      quests.on_save()
       achievements.check_all_achievements()
+      logic.check_clean_code()
+    end,
+  })
+
+  vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI', 'TextChanged', 'TextChangedI' }, {
+    group = group,
+    callback = function()
+      logic.track_keypress()
+      focus.tick()
     end,
   })
 
   vim.api.nvim_create_autocmd('VimLeavePre', {
+    group = group,
     callback = function()
       logic.add_total_time_spent()
       utils.track_night_coding()
       utils.track_morning_coding()
-
-      data = storage.load_data()
-      data.last_entry = nil
-      storage.save_data(data)
+      focus.flush()
     end,
   })
 end
 
-M.setup()
+function M.setup(opts)
+  config.setup(opts)
+
+  ensure_data_file()
+
+  local data = storage.load_data()
+  data.last_entry = os.date '%Y-%m-%d %H:%M:%S'
+  storage.save_data(data)
+
+  if storage.log_new_day() then
+    logic.add_xp(config.get().xp.new_day)
+    ui.random_luck_popup()
+    utils.calculate_all_lines_written()
+    utils.check_streak()
+    quests.generate_for_today()
+    achievements.check_all_achievements()
+  else
+    quests.generate_for_today()
+  end
+
+  register_commands()
+  register_autocommands()
+end
 
 return M

--- a/lua/gamify/katas.lua
+++ b/lua/gamify/katas.lua
@@ -1,0 +1,112 @@
+local M = {}
+
+M.list = {
+  {
+    id = 1,
+    title = 'Reverse String',
+    description = "Write a function 'solution(str)' that reverses the input string.",
+    initial_code = 'function solution(str)\n  -- Your code here\n  \nend',
+    tests = {
+      { input = 'hello', expected = 'olleh' },
+      { input = 'world', expected = 'dlrow' },
+      { input = 'lua', expected = 'aul' },
+    },
+    xp = 100,
+  },
+  {
+    id = 2,
+    title = 'Sum of Array',
+    description = "Write a function 'solution(arr)' that returns the sum of all numbers in an array.",
+    initial_code = 'function solution(arr)\n  -- Your code here\n  \nend',
+    tests = {
+      { input = { 1, 2, 3 }, expected = 6 },
+      { input = { 10, -5, 5 }, expected = 10 },
+      { input = {}, expected = 0 },
+    },
+    xp = 150,
+  },
+  {
+    id = 3,
+    title = 'Is Palindrome',
+    description = "Write a function 'solution(str)' that returns true if a string is a palindrome.",
+    initial_code = 'function solution(str)\n  -- Your code here\n  \nend',
+    tests = {
+      { input = 'racecar', expected = true },
+      { input = 'hello', expected = false },
+      { input = 'madam', expected = true },
+    },
+    xp = 200,
+  },
+  {
+    id = 4,
+    title = 'FizzBuzz',
+    description = "Write 'solution(n)' returning 'Fizz' if divisible by 3, 'Buzz' if by 5, 'FizzBuzz' if both, else the number as a string.",
+    initial_code = 'function solution(n)\n  -- Your code here\n  \nend',
+    tests = {
+      { input = 3, expected = 'Fizz' },
+      { input = 5, expected = 'Buzz' },
+      { input = 15, expected = 'FizzBuzz' },
+      { input = 7, expected = '7' },
+    },
+    xp = 150,
+  },
+  {
+    id = 5,
+    title = 'Count Vowels',
+    description = "Write 'solution(str)' that returns the number of vowels (a, e, i, o, u) in the string.",
+    initial_code = 'function solution(str)\n  -- Your code here\n  \nend',
+    tests = {
+      { input = 'hello', expected = 2 },
+      { input = 'sky', expected = 0 },
+      { input = 'aeiou', expected = 5 },
+    },
+    xp = 150,
+  },
+  {
+    id = 6,
+    title = 'Max of Array',
+    description = "Write 'solution(arr)' that returns the largest number in the array.",
+    initial_code = 'function solution(arr)\n  -- Your code here\n  \nend',
+    tests = {
+      { input = { 1, 7, 3 }, expected = 7 },
+      { input = { -5, -2, -9 }, expected = -2 },
+      { input = { 42 }, expected = 42 },
+    },
+    xp = 175,
+  },
+  {
+    id = 7,
+    title = 'Factorial',
+    description = "Write 'solution(n)' that returns n! (n factorial). solution(0) is 1.",
+    initial_code = 'function solution(n)\n  -- Your code here\n  \nend',
+    tests = {
+      { input = 0, expected = 1 },
+      { input = 5, expected = 120 },
+      { input = 6, expected = 720 },
+    },
+    xp = 200,
+  },
+  {
+    id = 8,
+    title = 'Fibonacci',
+    description = "Write 'solution(n)' that returns the n-th Fibonacci number (0-indexed: 0,1,1,2,3,5...).",
+    initial_code = 'function solution(n)\n  -- Your code here\n  \nend',
+    tests = {
+      { input = 0, expected = 0 },
+      { input = 1, expected = 1 },
+      { input = 7, expected = 13 },
+      { input = 10, expected = 55 },
+    },
+    xp = 250,
+  },
+}
+
+function M.daily_id()
+  local seed = 0
+  for _, b in ipairs { os.date('%Y%m%d'):byte(1, -1) } do
+    seed = seed + b
+  end
+  return (seed % #M.list) + 1
+end
+
+return M

--- a/lua/gamify/logic.lua
+++ b/lua/gamify/logic.lua
@@ -1,61 +1,111 @@
 local M = {}
 local storage = require 'gamify.storage'
 local utils = require 'gamify.utils'
+local config = require 'gamify.config'
 
--- A lower exponent B means it takes fewer XP to reach higher levels;
--- a smaller multiplier A also slows down level progression.
-local A = 0.001
-local B = 1.02
+local function level_for_xp(xp)
+  local lv = config.get().leveling
+  return math.floor(1 + lv.A * (xp ^ lv.B))
+end
+M.level_for_xp = level_for_xp
 
-function M.add_xp(amount, achievement)
-  -- print('add_xp called with amount:', amount)
+function M.xp_for_level(level)
+  local lv = config.get().leveling
+  if level <= 1 then
+    return 0
+  end
+  return ((level - 1) / lv.A) ^ (1 / lv.B)
+end
+
+-- opts.raw skips the prestige/focus multipliers for system rewards.
+function M.add_xp(amount, achievement, opts)
+  opts = opts or {}
   local data = storage.load_data()
 
   if achievement then
     data.achievements[achievement.name] = achievement.description
   end
 
-  data.xp = (data.xp or 0) + amount
+  local multiplier = 1
+  if not opts.raw then
+    local prestige = data.prestige or 0
+    multiplier = multiplier + prestige * config.get().prestige.xp_bonus_per_rank
+    multiplier = multiplier * require('gamify.focus').current_multiplier()
+  end
+
+  local gained = math.floor(amount * multiplier + 0.5)
+  data.xp = (data.xp or 0) + gained
+
+  local today = os.date '%Y-%m-%d'
+  data.daily_xp = data.daily_xp or {}
+  data.daily_xp[today] = (data.daily_xp[today] or 0) + gained
+
+  if config.get().ui.xp_popups and gained > 1 then
+    vim.schedule(function()
+      require('gamify.ui').show_xp_popup(gained)
+    end)
+  end
 
   local old_level = data.level or 1
-  local new_level = math.floor(1 + A * (data.xp ^ B))
+  local new_level = level_for_xp(data.xp)
 
   if new_level > old_level then
     data.level = new_level
-    -- print('Leveled up to:', new_level)
+    local ui = require 'gamify.ui'
+    ui.show_popup('LEVEL UP! You are now level ' .. new_level, 'Congratulations!', 'top_right')
+    if config.get().ui.confetti then
+      ui.show_falling_confetti(30, 3000)
+    end
   end
 
   storage.save_data(data)
-  -- print('XP after saving:', data.xp)
+  return gained
 end
 
 local function add_xp_for_lines_written(lines)
-  -- print 'adding xp for lines'
-  local xp = math.ceil(tonumber(lines) / 10)
-
+  local per = config.get().xp.per_lines
+  local xp = math.ceil(tonumber(lines) / per)
   M.add_xp(xp)
-end
-
-function M.add_achievement(achievement)
-  local data = storage.load_data()
-
-  if not vim.tbl_contains(data.achievements, achievement) then
-    table.insert(data.achievements, achievement)
-    storage.save_data(data)
-  end
 end
 
 function M.set_goal(description, deadline)
   local data = storage.load_data()
-
+  data.goals = data.goals or {}
   table.insert(data.goals, { description = description, deadline = deadline })
   storage.save_data(data)
 end
 
-function M.set_time_entry()
+function M.prestige()
   local data = storage.load_data()
-  data.last_time_entry = storage.last_entry_format
-  storage.save_data(data)
+  local cfg = config.get().prestige
+  if not cfg.enabled then
+    vim.notify('Prestige is disabled.', vim.log.levels.WARN, { title = 'Gamify' })
+    return
+  end
+  local level = data.level or 1
+  if level < cfg.level_required then
+    vim.notify(
+      string.format('You need level %d to prestige (currently %d).', cfg.level_required, level),
+      vim.log.levels.WARN,
+      { title = 'Gamify' }
+    )
+    return
+  end
+
+  vim.ui.input({ prompt = string.format('Prestige now? Resets XP for +%d%% permanent XP. Type YES: ', cfg.xp_bonus_per_rank * 100) }, function(input)
+    if input ~= 'YES' then
+      vim.notify('Prestige cancelled.', vim.log.levels.INFO, { title = 'Gamify' })
+      return
+    end
+    local d = storage.load_data()
+    d.prestige = (d.prestige or 0) + 1
+    d.xp = 0
+    d.level = 1
+    storage.save_data(d)
+    local ui = require 'gamify.ui'
+    ui.show_popup('PRESTIGE ' .. d.prestige .. '! Permanent XP bonus increased.', 'Prestige', 'top_right')
+    ui.show_falling_confetti(40, 4000)
+  end)
 end
 
 function M.get_data()
@@ -79,9 +129,8 @@ function M.add_total_time_spent()
 end
 
 function M.random_luck()
-  if math.random(40) == 1 then
-    local xp_amount = 50
-    M.add_xp(xp_amount)
+  if math.random(config.get().random_luck_chance) == 1 then
+    M.add_xp(config.get().xp.random_luck)
     local today_compliment = utils.compliments[math.random(#utils.compliments)]
     return today_compliment
   end
@@ -92,29 +141,36 @@ function M.track_lines()
   local data = storage.load_data()
   data.commit_hashes = data.commit_hashes or {}
 
-  local is_git_repo = vim.fn.system('git rev-parse --is-inside-work-tree'):match 'true'
+  local is_git_repo = vim.fn.system('git rev-parse --is-inside-work-tree 2>/dev/null'):match 'true'
   if not is_git_repo then
-    -- print 'Not in git repository. tracking skipped.'
     return
   end
 
-  local new_commit_handle = io.popen 'git rev-parse HEAD'
+  -- Check if there are any commits at all
+  local has_commits = vim.fn.system('git rev-parse --verify HEAD 2>/dev/null') ~= ''
+  if not has_commits then
+    return
+  end
+
+  local new_commit_handle = io.popen 'git rev-parse HEAD 2>/dev/null'
   if not new_commit_handle then
-    -- print 'Failed to get the latest commit hash.'
     return
   end
 
   local new_commit_hash = new_commit_handle:read('*a'):gsub('%s+', '')
   new_commit_handle:close()
 
-  if vim.tbl_contains(data.commit_hashes, new_commit_hash) then
-    -- print 'Commit already processed. Skipping...'
+  if new_commit_hash == '' or vim.tbl_contains(data.commit_hashes, new_commit_hash) then
     return
   end
 
-  local handle = io.popen 'git diff --numstat HEAD~1 HEAD'
+  -- Check if HEAD~1 exists
+  local has_parent = vim.fn.system('git rev-parse --verify HEAD~1 2>/dev/null') ~= ''
+  local diff_cmd = has_parent and 'git diff --numstat HEAD~1 HEAD 2>/dev/null' or 'git diff --numstat 4b825dc642cb6eb9a060e54bf8d69288fbee4904 HEAD 2>/dev/null'
+  -- 4b825dc642cb6eb9a060e54bf8d69288fbee4904 is the hash of an empty tree
+
+  local handle = io.popen(diff_cmd)
   if not handle then
-    -- print 'Failed to execute git diff.'
     return
   end
 
@@ -122,7 +178,6 @@ function M.track_lines()
   handle:close()
 
   if not result or result == '' then
-    -- print 'No changes detected in git diff.'
     return
   end
 
@@ -143,6 +198,104 @@ function M.track_lines()
   storage.save_data(data)
 
   add_xp_for_lines_written(tonumber(total_lines))
+  require('gamify.quests').on_commit()
+  if total_lines > 0 then
+    require('gamify.quests').on_lines(total_lines)
+  end
+end
+
+function M.track_keypress()
+  local data = storage.load_data()
+  local threshold = config.get().xp.per_keypresses
+  data.keypress_count = (data.keypress_count or 0) + 1
+
+  if data.keypress_count >= threshold then
+    data.keypress_count = 0
+    M.add_xp(1)
+  end
+
+  storage.save_data(data)
+end
+
+function M.get_role()
+  local data = storage.load_data()
+  local langs = data.lines_written_in_specified_langs or {}
+  
+  local max_lines = 0
+  local dominant_lang = nil
+  
+  for lang, lines in pairs(langs) do
+    if lines > max_lines then
+      max_lines = lines
+      dominant_lang = lang
+    end
+  end
+  
+  if not dominant_lang or max_lines == 0 then
+    return "Novice Coder"
+  end
+  
+  local roles = {
+    ['JavaScript'] = "Frontend Wizard",
+    ['TypeScript'] = "Frontend Wizard",
+    ['JavaScript (React)'] = "Frontend Wizard",
+    ['TypeScript (React)'] = "Frontend Wizard",
+    ['HTML'] = "Frontend Wizard",
+    ['CSS'] = "Frontend Wizard",
+    ['Python'] = "Data Alchemist",
+    ['C'] = "Systems Ninja",
+    ['C++'] = "Systems Ninja",
+    ['Rust'] = "Systems Ninja",
+    ['Go'] = "Cloud Voyager",
+    ['Lua'] = "Plugin Sorcerer",
+    ['Vim Script'] = "Plugin Sorcerer",
+    ['Shell'] = "Terminal Overlord",
+  }
+  
+  return roles[dominant_lang] or (dominant_lang .. " Explorer")
+end
+
+function M.get_statusline_text()
+  local data = storage.load_data()
+  if not data then return "" end
+  return string.format("Lvl %d 🔥 %d", data.level or 1, data.day_streak or 1)
+end
+
+-- e.g. "Lvl 12 [████░░] 🔥7"
+function M.get_statusline_bar(bar_width)
+  bar_width = bar_width or 6
+  local data = storage.load_data()
+  if not data then return '' end
+  local level = data.level or 1
+  local xp = data.xp or 0
+  local cur = M.xp_for_level(level)
+  local nxt = M.xp_for_level(level + 1)
+  local progress = nxt > cur and (xp - cur) / (nxt - cur) or 0
+  progress = math.max(0, math.min(1, progress))
+  local filled = math.floor(progress * bar_width)
+  local bar = string.rep('█', filled) .. string.rep('░', bar_width - filled)
+  return string.format('Lvl %d [%s] 🔥%d', level, bar, data.day_streak or 1)
+end
+
+-- One clean-code payout per buffer per session, so `:w` can't farm XP.
+local clean_code_awarded = {}
+
+function M.check_clean_code()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local diagnostics = vim.diagnostic.get(bufnr, { severity = vim.diagnostic.severity.ERROR })
+
+  if #diagnostics ~= 0 then
+    clean_code_awarded[bufnr] = nil
+    return
+  end
+
+  if config.get().clean_code_once_per_buffer and clean_code_awarded[bufnr] then
+    return
+  end
+
+  clean_code_awarded[bufnr] = true
+  M.add_xp(config.get().xp.clean_code)
+  require('gamify.quests').on_clean_code()
 end
 
 return M

--- a/lua/gamify/quests.lua
+++ b/lua/gamify/quests.lua
@@ -1,0 +1,161 @@
+local M = {}
+
+local storage = require 'gamify.storage'
+local config = require 'gamify.config'
+
+local quest_pool = {
+  { id = 'lines_150', type = 'lines', target = 150, xp = 80, description = 'Write 150 lines of code' },
+  { id = 'lines_300', type = 'lines', target = 300, xp = 150, description = 'Write 300 lines of code' },
+  { id = 'commits_2', type = 'commits', target = 2, xp = 100, description = 'Make 2 commits' },
+  { id = 'commits_5', type = 'commits', target = 5, xp = 200, description = 'Make 5 commits' },
+  { id = 'clean_3', type = 'clean_code', target = 3, xp = 90, description = 'Save 3 files with zero errors' },
+  { id = 'fix_3', type = 'errors', target = 3, xp = 120, description = 'Fix 3 diagnostic errors' },
+  { id = 'kata_1', type = 'kata', target = 1, xp = 150, description = 'Complete 1 coding kata' },
+  { id = 'game_1', type = 'game', target = 1, xp = 80, description = 'Play a mini-game' },
+}
+
+local function today()
+  return os.date '%Y-%m-%d'
+end
+
+local function pick_quests(count)
+  local pool = vim.deepcopy(quest_pool)
+
+  -- Seed from the date so the same quests are picked all day, then restore
+  -- entropy so the rest of the session's math.random isn't deterministic.
+  local seed = 0
+  for _, b in ipairs { today():byte(1, -1) } do
+    seed = seed + b
+  end
+  math.randomseed(seed)
+  for i = #pool, 2, -1 do
+    local j = math.random(i)
+    pool[i], pool[j] = pool[j], pool[i]
+  end
+  math.randomseed(os.time())
+
+  local picked = {}
+  for i = 1, math.min(count, #pool) do
+    local q = pool[i]
+    table.insert(picked, {
+      id = q.id,
+      type = q.type,
+      target = q.target,
+      xp = q.xp,
+      description = q.description,
+      progress = 0,
+      done = false,
+    })
+  end
+  return picked
+end
+
+function M.generate_for_today()
+  if not config.get().quests.enabled then
+    return
+  end
+  local data = storage.load_data()
+  data.quests = data.quests or { date = nil, active = {}, bonus_claimed = false }
+
+  if data.quests.date ~= today() then
+    data.quests.date = today()
+    data.quests.active = pick_quests(config.get().quests.count)
+    data.quests.bonus_claimed = false
+    storage.save_data(data)
+  end
+end
+
+local function progress(qtype, amount)
+  if not config.get().quests.enabled then
+    return
+  end
+  local data = storage.load_data()
+  local q = data.quests
+  if not q or q.date ~= today() or type(q.active) ~= 'table' then
+    return
+  end
+
+  local logic = require 'gamify.logic'
+  local ui = require 'gamify.ui'
+  local changed = false
+
+  for _, quest in ipairs(q.active) do
+    if quest.type == qtype and not quest.done then
+      quest.progress = math.min(quest.target, quest.progress + amount)
+      changed = true
+      if quest.progress >= quest.target then
+        quest.done = true
+        storage.save_data(data)
+        logic.add_xp(quest.xp)
+        if config.get().ui.popups then
+          ui.show_popup('Quest complete: ' .. quest.description .. ' (+' .. quest.xp .. ' XP)', 'Daily Quest', 'bottom_left')
+        end
+        -- add_xp wrote its own copy; re-read so later saves don't clobber it
+        data = storage.load_data()
+        q = data.quests
+      end
+    end
+  end
+
+  if changed then
+    storage.save_data(data)
+  end
+
+  if not q.bonus_claimed and #q.active > 0 then
+    local all_done = true
+    for _, quest in ipairs(q.active) do
+      if not quest.done then
+        all_done = false
+        break
+      end
+    end
+    if all_done then
+      data = storage.load_data()
+      data.quests.bonus_claimed = true
+      storage.save_data(data)
+      logic.add_xp(config.get().quests.completion_bonus)
+      if config.get().ui.popups then
+        ui.show_popup('All daily quests cleared! +' .. config.get().quests.completion_bonus .. ' bonus XP', 'Daily Quests', 'top_right')
+      end
+      if config.get().ui.confetti then
+        ui.show_falling_confetti(25, 2500)
+      end
+    end
+  end
+end
+
+function M.on_lines(n)
+  progress('lines', n)
+end
+
+function M.on_commit()
+  progress('commits', 1)
+end
+
+function M.on_clean_code()
+  progress('clean_code', 1)
+end
+
+function M.on_errors_fixed(n)
+  progress('errors', n)
+end
+
+function M.on_kata()
+  progress('kata', 1)
+end
+
+function M.on_game()
+  progress('game', 1)
+end
+
+function M.on_save() end
+
+function M.get_active()
+  local data = storage.load_data()
+  if data.quests and data.quests.date == today() then
+    return data.quests.active or {}
+  end
+  return {}
+end
+
+return M

--- a/lua/gamify/storage.lua
+++ b/lua/gamify/storage.lua
@@ -20,6 +20,21 @@ M.data_json_format = {
   day_streak = 1,
   commit_hashes = {},
   gamify_cmd_count = 0,
+  keypress_count = 0,
+  prestige = 0,
+  completed_katas = {}, -- keyed by tostring(kata_id) (JSON has no integer keys)
+  daily_kata_done = nil,
+  daily_xp = {}, -- ['YYYY-MM-DD'] = xp, drives the heatmap
+  quests = {
+    date = nil,
+    active = {},
+    bonus_claimed = false,
+  },
+  high_scores = {
+    snake = 0,
+    saper = nil, -- best time in seconds
+    sudoku = nil, -- best time in seconds
+  },
 }
 
 function M.load_data()
@@ -31,14 +46,23 @@ function M.load_data()
   local content = file:read '*a'
   file:close()
 
-  local data = vim.fn.json_decode(content)
+  local ok, data = pcall(vim.fn.json_decode, content)
+  if not ok or type(data) ~= 'table' then
+    return vim.deepcopy(M.data_json_format)
+  end
 
-  local defaults = M.data_json_format
-  for k, v in pairs(defaults) do
-    if data[k] == nil then
-      data[k] = v
+  -- Backfill defaults (including nested tables) onto older data files.
+  local is_list = vim.islist or vim.tbl_islist
+  local function backfill(target, defaults)
+    for k, v in pairs(defaults) do
+      if target[k] == nil then
+        target[k] = vim.deepcopy(v)
+      elseif type(v) == 'table' and type(target[k]) == 'table' and not is_list(v) then
+        backfill(target[k], v)
+      end
     end
   end
+  backfill(data, M.data_json_format)
 
   return data
 end

--- a/lua/gamify/ui.lua
+++ b/lua/gamify/ui.lua
@@ -3,10 +3,36 @@ local logic = require 'gamify.logic'
 local storage = require 'gamify.storage'
 local utils = require 'gamify.utils'
 
-local function center_text(text, width)
-  local padding = math.floor((width - #text) / 2)
-  return string.rep(' ', math.max(padding, 0)) .. text
+function M.show_xp_popup(amount)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local line = cursor[1] - 1
+  
+  local ns_id = vim.api.nvim_create_namespace('gamify_xp')
+  local opts = {
+    virt_text = {{ "+" .. amount .. " XP", "String" }},
+    virt_text_pos = 'eol',
+  }
+  
+  local id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, line, 0, opts)
+  
+  vim.defer_fn(function()
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_del_extmark(bufnr, ns_id, id)
+    end
+  end, 1000)
 end
+
+local function center_text(text, total_width)
+  local text_len = vim.fn.strdisplaywidth(text)
+  if text_len >= total_width then
+    return text
+  end
+  local left_spaces = math.floor((total_width - text_len) / 2)
+  local right_spaces = total_width - text_len - left_spaces
+  return string.rep(' ', left_spaces) .. text .. string.rep(' ', right_spaces)
+end
+M.center_text = center_text
 
 function M.show_status_window(all_achievements_len)
   local buffer = vim.api.nvim_create_buf(false, true)
@@ -21,30 +47,87 @@ function M.show_status_window(all_achievements_len)
 
   local user_achievements_len = utils.get_table_length(data.achievements)
 
-  local ui_width = 70
+  local ui_width = 80
+
+  local xp = data.xp or 0
+  local level = data.level or 1
+
+  local current_level_xp = logic.xp_for_level(level)
+  local next_level_xp = logic.xp_for_level(level + 1)
+  local progress = next_level_xp > current_level_xp and (xp - current_level_xp) / (next_level_xp - current_level_xp) or 0
+  progress = math.max(0, math.min(1, progress))
+
+  local bar_width = 50
+  local filled_width = math.floor(progress * bar_width)
+  local bar = string.rep('█', filled_width) .. string.rep('░', bar_width - filled_width)
+  local progress_text = string.format('Progress: %s %.1f%%', bar, progress * 100)
+
+  local role = logic.get_role()
+  local prestige = data.prestige or 0
+  local level_label = 'Level: ' .. level
+  if prestige > 0 then
+    level_label = level_label .. ('  ✪'):rep(1) .. ' Prestige ' .. prestige
+  end
 
   local lines = {
-    center_text('   ____                 _  __       ', ui_width),
-    center_text('  / ___| __ _ _ __ ___ (_)/ _|_   _ ', ui_width),
+    center_text('   ____                 _  __', ui_width),
+    center_text('  / ___| __ _ _ __ ___ (_)/ _|_   _', ui_width),
     center_text(" | |  _ / _` | '_ ` _ \\| | |_| | | |", ui_width),
     center_text(' | |_| | (_| | | | | | | |  _| |_| |', ui_width),
     center_text('  \\____|\\__,_|_| |_| |_|_|_|  \\__, |', ui_width),
-    center_text('                              |___/ ', ui_width),
+    center_text('                              |___/', ui_width),
     '',
-    center_text('🎮 Gamify.nvim Status 🎮', ui_width),
+    center_text('🎮 Gamify.nvim Dashboard 🎮', ui_width),
     '',
-    center_text('XP: ' .. data.xp, ui_width),
-    center_text('Level: ' .. data.level, ui_width),
+    center_text('Role: ' .. role, ui_width),
+    center_text(level_label, ui_width),
+    center_text('XP: ' .. math.floor(xp) .. ' / ' .. math.floor(next_level_xp), ui_width),
+    center_text(progress_text, ui_width),
+    center_text(require('gamify.focus').status_text(), ui_width),
+    '',
+    center_text('─── Statistics ───', ui_width),
     center_text('Achievements: ' .. user_achievements_len .. '/' .. all_achievements_len, ui_width),
-    center_text('Total lines written: ' .. data.lines_written, ui_width),
-    center_text('You made : ' .. #data.commit_hashes .. ' commits to git!', ui_width),
-    '',
-    center_text(time_message, ui_width),
-    '',
-    center_text("You're on a " .. data.day_streak .. ' day streak.', ui_width),
-    '',
-    center_text('Press esc key to close.', ui_width),
+    center_text('Total lines: ' .. data.lines_written, ui_width),
+    center_text('Git commits: ' .. #data.commit_hashes, ui_width),
+    center_text('Streak: ' .. data.day_streak .. ' days 🔥', ui_width),
   }
+
+  local nxt = require('gamify.achievements').next_progress()
+  if nxt then
+    local nb_width = 24
+    local nf = math.floor((nxt.percent / 100) * nb_width)
+    local nbar = string.rep('█', nf) .. string.rep('░', nb_width - nf)
+    table.insert(lines, center_text(string.format('Next: %s  %s %d/%d', nxt.name, nbar, nxt.current, nxt.target), ui_width))
+  end
+
+  vim.list_extend(lines, {
+    '',
+    center_text('─── High Scores ───', ui_width),
+    center_text(string.format('Snake: %d pts | Saper: %s | Sudoku: %s',
+      data.high_scores.snake or 0,
+      data.high_scores.saper and (data.high_scores.saper .. "s") or "N/A",
+      data.high_scores.sudoku and (data.high_scores.sudoku .. "s") or "N/A"
+    ), ui_width),
+    '',
+    center_text('─── Daily Quests ───', ui_width),
+  })
+
+  local quests = require('gamify.quests').get_active()
+  if #quests == 0 then
+    table.insert(lines, center_text('No active quests today.', ui_width))
+  else
+    for _, q in ipairs(quests) do
+      local mark = q.done and '✅' or '⬜'
+      table.insert(lines, center_text(string.format('%s %s  (%d/%d, +%d XP)', mark, q.description, q.progress, q.target, q.xp), ui_width))
+    end
+  end
+
+  vim.list_extend(lines, {
+    '',
+    center_text('─── Menu ───', ui_width),
+    center_text('(a) Achievements  (s) Lang Stats  (c) Challenges  (h) Heatmap  (p) Share', ui_width),
+    center_text('(g) Snake  (m) Saper  (u) Sudoku  (q) Quit', ui_width),
+  })
 
   local opts = {
     style = 'minimal',
@@ -58,13 +141,56 @@ function M.show_status_window(all_achievements_len)
 
   local window = vim.api.nvim_open_win(buffer, true, opts)
   vim.api.nvim_buf_set_lines(buffer, 0, -1, false, lines)
-  vim.api.nvim_buf_set_keymap(buffer, 'n', '<Esc>', ':q<CR>', { noremap = true, silent = true })
+
+  -- Helper to close dashboard and run action
+  local function action(callback)
+    return function()
+      if vim.api.nvim_win_is_valid(window) then
+        vim.api.nvim_win_close(window, true)
+      end
+      callback()
+    end
+  end
+
+  vim.keymap.set('n', 'a', action(function() M.show_achievements() end), { buffer = buffer })
+  vim.keymap.set('n', 's', action(function() M.show_languages_ui() end), { buffer = buffer })
+  vim.keymap.set('n', 'c', action(function() require('gamify.challenges').show_challenges_menu() end), { buffer = buffer })
+  vim.keymap.set('n', 'h', action(function() M.show_heatmap() end), { buffer = buffer })
+  vim.keymap.set('n', 'p', action(function() M.show_share_card() end), { buffer = buffer })
+  vim.keymap.set('n', 'g', action(function() require('gamify.games').start_snake() end), { buffer = buffer })
+  vim.keymap.set('n', 'm', action(function() require('gamify.games').start_minesweeper() end), { buffer = buffer })
+  vim.keymap.set('n', 'u', action(function() require('gamify.games').start_sudoku() end), { buffer = buffer })
+  vim.keymap.set('n', 'q', action(function() end), { buffer = buffer })
+  vim.keymap.set('n', '<Esc>', action(function() end), { buffer = buffer })
+
   vim.api.nvim_buf_set_option(buffer, 'modifiable', false)
+end
+
+local function wrap_text(text, max_width)
+  local lines = {}
+  for _, line in ipairs(vim.split(text, '\n')) do
+    local current_line = ''
+    for word in line:gmatch '%S+' do
+      if #current_line + #word + 1 <= max_width then
+        if current_line == '' then
+          current_line = word
+        else
+          current_line = current_line .. ' ' .. word
+        end
+      else
+        table.insert(lines, current_line)
+        current_line = word
+      end
+    end
+    table.insert(lines, current_line)
+  end
+  return lines
 end
 
 function M.show_popup(text, title, corner)
   local width = math.min(50, vim.o.columns - 4)
-  local height = 4
+  local text_lines = wrap_text(text, width - 2)
+  local height = #text_lines + 1
   local row, col
 
   if corner == 'top_left' then
@@ -81,11 +207,8 @@ function M.show_popup(text, title, corner)
 
   local buf = vim.api.nvim_create_buf(false, true)
 
-  local text_lines = vim.split(text, '\n')
-
   local lines = { '🟢 [' .. title .. ']' }
   vim.list_extend(lines, text_lines)
-  -- table.insert(lines, 'Press any key to dismiss')
 
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
 
@@ -166,7 +289,7 @@ function M.show_languages_ui()
   end
 
   table.insert(ui_lines, '')
-  table.insert(ui_lines, center_text('Press esc key to close.', ui_width))
+  table.insert(ui_lines, center_text('Press (b) to go back | (q) to close.', ui_width))
 
   local buffer = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(buffer, 0, -1, false, ui_lines)
@@ -183,18 +306,14 @@ function M.show_languages_ui()
 
   local window = vim.api.nvim_open_win(buffer, true, opts)
 
-  vim.api.nvim_buf_set_keymap(buffer, 'n', '<Esc>', ':q<CR>', { noremap = true, silent = true })
-  vim.api.nvim_buf_set_option(buffer, 'modifiable', false)
-end
+  vim.keymap.set('n', 'b', function()
+    vim.api.nvim_win_close(window, true)
+    M.show_status_window(require('gamify.achievements').get_achievements_table_length())
+  end, { buffer = buffer })
 
-local function center_text(text, total_width)
-  local text_len = vim.fn.strdisplaywidth(text)
-  if text_len >= total_width then
-    return text
-  end
-  local left_spaces = math.floor((total_width - text_len) / 2)
-  local right_spaces = total_width - text_len - left_spaces
-  return string.rep(' ', left_spaces) .. text .. string.rep(' ', right_spaces)
+  vim.api.nvim_buf_set_keymap(buffer, 'n', '<Esc>', ':q<CR>', { noremap = true, silent = true })
+  vim.api.nvim_buf_set_keymap(buffer, 'n', 'q', ':q<CR>', { noremap = true, silent = true })
+  vim.api.nvim_buf_set_option(buffer, 'modifiable', false)
 end
 
 local function create_achievement_box(name, description, box_width)
@@ -247,7 +366,7 @@ function M.show_achievements()
     table.insert(lines, '')
   end
 
-  table.insert(lines, center_text('Press Esc to close', box_width))
+  table.insert(lines, center_text('Press (b) to go back | (q) to close', box_width))
 
   local width = box_width + 8
   local height = #lines + 2
@@ -301,7 +420,13 @@ function M.show_achievements()
     end
   end
 
+  vim.keymap.set('n', 'b', function()
+    vim.api.nvim_win_close(win, true)
+    M.show_status_window(require('gamify.achievements').get_achievements_table_length())
+  end, { buffer = buffer })
+
   vim.api.nvim_buf_set_keymap(buffer, 'n', '<Esc>', ':q<CR>', { noremap = true, silent = true })
+  vim.api.nvim_buf_set_keymap(buffer, 'n', 'q', ':q<CR>', { noremap = true, silent = true })
   vim.api.nvim_buf_set_option(buffer, 'modifiable', false)
 end
 
@@ -419,6 +544,146 @@ function M.show_falling_confetti(count, duration_ms)
   end
 
   timer:start(0, 80, vim.schedule_wrap(animate))
+end
+
+local function open_simple_float(lines, width)
+  local height = math.min(#lines + 2, vim.o.lines - 4)
+  local buffer = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buffer, 0, -1, false, lines)
+
+  local win = vim.api.nvim_open_win(buffer, true, {
+    style = 'minimal',
+    relative = 'editor',
+    width = width,
+    height = height,
+    row = math.floor((vim.o.lines - height) / 2),
+    col = math.floor((vim.o.columns - width) / 2),
+    border = 'rounded',
+  })
+
+  vim.keymap.set('n', 'b', function()
+    vim.api.nvim_win_close(win, true)
+    M.show_status_window(require('gamify.achievements').get_achievements_table_length())
+  end, { buffer = buffer })
+  vim.api.nvim_buf_set_keymap(buffer, 'n', '<Esc>', ':q<CR>', { noremap = true, silent = true })
+  vim.api.nvim_buf_set_keymap(buffer, 'n', 'q', ':q<CR>', { noremap = true, silent = true })
+  vim.api.nvim_buf_set_option(buffer, 'modifiable', false)
+  return buffer, win
+end
+
+function M.show_heatmap()
+  local data = storage.load_data()
+  local daily = data.daily_xp or {}
+
+  local levels = { '·', '░', '▒', '▓', '█' }
+  local function cell(xp)
+    if xp <= 0 then return levels[1] end
+    if xp < 50 then return levels[2] end
+    if xp < 150 then return levels[3] end
+    if xp < 400 then return levels[4] end
+    return levels[5]
+  end
+
+  local weeks = 26
+  local today_secs = os.time()
+  -- align to the most recent Sunday so each column is one week
+  local wday = tonumber(os.date('%w', today_secs))
+  local grid = {} -- grid[row=0..6][col]
+  for r = 0, 6 do grid[r] = {} end
+
+  local total_days = weeks * 7
+  local start_secs = today_secs - (total_days - 1 - wday) * 86400
+  for i = 0, total_days - 1 do
+    local day_secs = start_secs + i * 86400
+    if day_secs <= today_secs then
+      local key = os.date('%Y-%m-%d', day_secs)
+      local col = math.floor(i / 7)
+      local row = tonumber(os.date('%w', day_secs))
+      grid[row][col + 1] = cell(daily[key] or 0)
+    end
+  end
+
+  local lines = {
+    center_text('📅 Activity Heatmap (last 26 weeks)', weeks + 8),
+    '',
+  }
+  local day_labels = { [1] = 'Mon', [3] = 'Wed', [5] = 'Fri' }
+  for r = 0, 6 do
+    local row_str = (day_labels[r] or '   ') .. ' '
+    for c = 1, weeks do
+      row_str = row_str .. (grid[r][c] or ' ')
+    end
+    table.insert(lines, row_str)
+  end
+  table.insert(lines, '')
+  table.insert(lines, '    Less ' .. table.concat(levels, ' ') .. ' More')
+  table.insert(lines, '')
+
+  local active_days, total_xp = 0, 0
+  for _, v in pairs(daily) do
+    if v > 0 then active_days = active_days + 1 end
+    total_xp = total_xp + v
+  end
+  table.insert(lines, string.format('    Active days: %d   |   Lifetime XP logged: %d', active_days, total_xp))
+  table.insert(lines, '')
+  table.insert(lines, center_text('Press (b) to go back | (q) to close', weeks + 8))
+
+  open_simple_float(lines, weeks + 12)
+end
+
+function M.show_share_card()
+  local data = storage.load_data()
+  local role = logic.get_role()
+  local lvl = data.level or 1
+  local prestige = data.prestige or 0
+  local achievements_n = utils.get_table_length(data.achievements)
+  local total_achievements = require('gamify.achievements').get_achievements_table_length()
+
+  local langs = {}
+  for lang, n in pairs(data.lines_written_in_specified_langs or {}) do
+    if lang ~= 'Unknown' and n > 0 then
+      table.insert(langs, { lang = lang, n = n })
+    end
+  end
+  table.sort(langs, function(a, b) return a.n > b.n end)
+  local top = {}
+  for i = 1, math.min(3, #langs) do
+    table.insert(top, langs[i].lang)
+  end
+  local top_str = #top > 0 and table.concat(top, ', ') or 'none yet'
+
+  local prestige_str = prestige > 0 and (' ✪' .. prestige) or ''
+  local W = 46
+  local function row(text)
+    local pad = W - 2 - vim.fn.strdisplaywidth(text)
+    if pad < 0 then pad = 0 end
+    return '┃ ' .. text .. string.rep(' ', pad) .. '┃'
+  end
+
+  local card = {
+    '┏' .. string.rep('━', W - 1) .. '┓',
+    row('🎮 GAMIFY.NVIM CHARACTER CARD'),
+    '┣' .. string.rep('━', W - 1) .. '┫',
+    row('Role:    ' .. role .. prestige_str),
+    row('Level:   ' .. lvl .. '   XP: ' .. math.floor(data.xp or 0)),
+    row('Streak:  ' .. (data.day_streak or 1) .. ' days'),
+    row('Lines:   ' .. (data.lines_written or 0)),
+    row('Commits: ' .. #(data.commit_hashes or {})),
+    row('Top:     ' .. top_str),
+    row('Trophies:' .. ' ' .. achievements_n .. '/' .. total_achievements),
+    '┗' .. string.rep('━', W - 1) .. '┛',
+  }
+
+  local lines = { center_text('🪪 Share Card', W + 6), '' }
+  vim.list_extend(lines, card)
+  table.insert(lines, '')
+  table.insert(lines, center_text('(y) yank to clipboard | (b) back | (q) close', W + 6))
+
+  local buffer, win = open_simple_float(lines, W + 6)
+  vim.keymap.set('n', 'y', function()
+    vim.fn.setreg('+', table.concat(card, '\n'))
+    vim.notify('Character card copied to clipboard!', vim.log.levels.INFO, { title = 'Gamify' })
+  end, { buffer = buffer })
 end
 
 function M.show_special_popup(name)

--- a/lua/gamify/utils.lua
+++ b/lua/gamify/utils.lua
@@ -63,39 +63,53 @@ function M.check_hour_difference(time1, time2)
   return diff_in_seconds / 3600
 end
 
+-- Day number since epoch; comparing these avoids DST / 86400s drift.
+local function date_to_day_number(date_string)
+  local year, month, day = date_string:match '(%d+)-(%d+)-(%d+)'
+  if not year then
+    return nil
+  end
+  local t = os.time { year = year, month = month, day = day, hour = 12, min = 0, sec = 0 }
+  return math.floor(t / 86400)
+end
+
 function M.check_streak()
   local data = storage.load_data()
   if not data or type(data.date) ~= 'table' or #data.date == 0 then
     return 0
   end
 
-  local dates = data.date
-  local streak = 1
-  local one_day_seconds = 86400
-
-  -- convert dates to seconds since epoch
-  local timestamps = {}
-  for _, date in ipairs(dates) do
-    local year, month, day = date:match '(%d+)-(%d+)-(%d+)'
-    local time = os.time { year = year, month = month, day = day, hour = 0, min = 0, sec = 0 }
-    table.insert(timestamps, time)
+  local seen = {}
+  local days = {}
+  for _, date in ipairs(data.date) do
+    local dn = date_to_day_number(date)
+    if dn and not seen[dn] then
+      seen[dn] = true
+      table.insert(days, dn)
+    end
   end
 
-  table.sort(timestamps, function(a, b)
+  table.sort(days, function(a, b)
     return a > b
   end)
 
-  for i = 2, #timestamps do
-    local difference = os.difftime(timestamps[i - 1], timestamps[i])
-    if difference <= one_day_seconds then
-      streak = streak + 1
-    else
-      break
+  -- A streak is broken unless the latest logged day is today or yesterday.
+  local today = math.floor(os.time() / 86400)
+  local streak = 0
+  if days[1] and (today - days[1]) <= 1 then
+    streak = 1
+    for i = 2, #days do
+      if days[i - 1] - days[i] == 1 then
+        streak = streak + 1
+      else
+        break
+      end
     end
   end
 
   data.day_streak = streak
   storage.save_data(data)
+  return streak
 end
 
 function M.get_table_length(t)
@@ -104,18 +118,6 @@ function M.get_table_length(t)
     count = count + 1
   end
   return count
-end
-
--- TODO: unify time and fix inconsistencies
-function M.hours_in_nvim()
-  local data = storage.load_data()
-  local last_time = data.last_time_entry
-  if last_time then
-    local current_time = os.time()
-    local time_diff = os.difftime(current_time, last_time)
-    return time_diff
-  end
-  return 0
 end
 
 -- returns difference in hours
@@ -137,6 +139,7 @@ function M.calculate_time_difference()
   return time_diff / 3600
 end
 
+-- Must not mutate last_entry: the session boundary is owned by add_total_time_spent.
 function M.track_night_coding()
   local data = storage.load_data()
   local current_time = os.date '%Y-%m-%d %H:%M:%S'
@@ -146,19 +149,15 @@ function M.track_night_coding()
     local last_entry_parsed = M.parse_time(data.last_entry)
     if last_entry_parsed then
       local last_hour = tonumber(last_entry_parsed.hour)
-      -- Condition: hour >= 23 (11PM) OR hour < 4 (midnight–3AM)
       if (last_hour >= 23) or (last_hour < 4) then
         data.code_nights = (data.code_nights or 0) + 1
+        storage.save_data(data)
       end
     end
   end
-
-  data.last_entry = current_time
-  storage.save_data(data)
 end
 
--- Morning is 06:00–10:59
--- If the 'last_entry' was in that window and you've coded >= 3 hrs, increment code_mornings.
+-- Read-only on last_entry, same as track_night_coding.
 function M.track_morning_coding()
   local data = storage.load_data()
   local current_time = os.date '%Y-%m-%d %H:%M:%S'
@@ -168,15 +167,12 @@ function M.track_morning_coding()
     local last_entry_parsed = M.parse_time(data.last_entry)
     if last_entry_parsed then
       local last_hour = tonumber(last_entry_parsed.hour)
-      -- Condition: hour >= 6 (6AM) and hour < 11 (10:59AM)
       if last_hour >= 6 and last_hour < 11 then
         data.code_mornings = (data.code_mornings or 0) + 1
+        storage.save_data(data)
       end
     end
   end
-
-  data.last_entry = current_time
-  storage.save_data(data)
 end
 
 function M.get_file_language(extension)
@@ -242,14 +238,6 @@ function M.calculate_all_lines_written()
 
   data.lines_written = all_lines
   storage.save_data(data)
-end
-
-function M.get_day_streak()
-  local data = storage.load_data()
-  local days_in_nvim = data.date
-
-  for i = 1, #days_in_nvim do
-  end
 end
 
 return M


### PR DESCRIPTION
…… (#15)

* feat: add config, daily quests, focus combo, prestige, heatmap and share card

Introduce setup(opts) configuration and several gameplay systems, plus fix core tracking bugs.

Features:
- config.lua: setup(opts) with tunable XP/quests/focus/prestige/UI; remove the implicit setup() auto-call on require
- quests.lua: daily quests with per-day generation, progress tracking and a completion bonus
- focus.lua: focus combo that multiplies XP for uninterrupted coding
- prestige system (:GamifyPrestige) granting a permanent XP bonus
- activity heatmap (:GamifyHeatmap) and shareable character card (:GamifyShare)
- katas.lua: split kata definitions out, add more katas and a kata of the day
- statusline bar variant, :GamifyStats and :GamifyReset commands

Fixes:
- persist gamify_cmd_count and correct the First Gamify Run condition
- Night Owl / Early Bird off-by-one (>= 5 instead of == 4)
- stop night/morning trackers from clobbering last_entry
- calendar-based streak that resets when broken
- clean-code bonus limited to once per buffer per session
- batch achievement unlock popups instead of a staggered queue
- remove dead code (get_day_streak, hours_in_nvim, add_achievement)

* Revise README with new images and cleanup

Updated README.md to include new screenshots and remove TODO comments.